### PR TITLE
fix for timers running 1 minute short

### DIFF
--- a/g32-display.yaml
+++ b/g32-display.yaml
@@ -3152,6 +3152,7 @@ script:
                 {
                   if( id(timer_h) > 0 )
                   {
+                    id(timer_s) = 59;
                     id(timer_m) = 59;
                     id(timer_h) = id(timer_h) - 1;
                   }


### PR DESCRIPTION
I noticed a small issue where the timer seems to start with about one minute missing on the clock.
E.g. staring a 2h timer will start with 1h59m to go.

This change seems to resolve the issue in my tests.