### PR TITLE
add MEATER detection to esp32_ble_tracker

### DIFF
--- a/g32-display.yaml
+++ b/g32-display.yaml
@@ -210,13 +210,18 @@ wifi:
 #            ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
 #            ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
 #          }
-#          else if (x.get_name().rfind("MEATER+", 0) == 0) {
+#          if (x.get_name().rfind("MEATER+", 0) == 0) {
 #            ESP_LOGI("ble_adv", "Meater+ gefunden");
 #            ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
 #            ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
 #          }
-#          else if (x.get_name().rfind("MEATER", 0) == 0) {
+#          if (x.get_name() == "MEATER") {
 #            ESP_LOGI("ble_adv", "Meater gefunden");
+#            ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
+#            ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
+#          }
+#          if (x.get_name() == "MEATER BLOCK") {
+#            ESP_LOGI("ble_adv", "Meater Block gefunden");
 #            ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
 #            ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
 #          }

--- a/g32-display.yaml
+++ b/g32-display.yaml
@@ -201,7 +201,7 @@ wifi:
     ssid: ${ap_ssid}
     password: ${ap_password}
 
-#esp32_ble_tracker:
+# esp32_ble_tracker:
 #  on_ble_advertise:
 #    then:
 #      - lambda: |-
@@ -210,8 +210,13 @@ wifi:
 #            ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
 #            ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
 #          }
-#          if (x.get_name().rfind("MEATER+", 0) == 0) {
+#          else if (x.get_name().rfind("MEATER+", 0) == 0) {
 #            ESP_LOGI("ble_adv", "Meater+ gefunden");
+#            ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
+#            ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
+#          }
+#          else if (x.get_name().rfind("MEATER", 0) == 0) {
+#            ESP_LOGI("ble_adv", "Meater gefunden");
 #            ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
 #            ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
 #          }


### PR DESCRIPTION
The esp32_ble_tracker logging is updated to show available MEATER® probes, too.